### PR TITLE
Add onSelectedRangeChange

### DIFF
--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -16,6 +16,11 @@ public struct SwiftDownEditor: UIViewRepresentable {
       onTextChange(text)
     }
   }
+    @Binding var selectedRange: NSRange {
+      didSet {
+        onSelectedRangeChange(selectedRange)
+      }
+    }
 
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
@@ -26,6 +31,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     private(set) var textAlignment: TextAlignment = .leading
 
     public var onTextChange: (String) -> Void = { _ in }
+    private(set) var onSelectedRangeChange: (NSRange) -> Void = { _ in }
     let engine = MarkdownEngine()
 
     public init(
@@ -33,6 +39,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
       onTextChange: @escaping (String) -> Void = { _ in }
     ) {
       _text = text
+      _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
     }
 
@@ -84,6 +91,10 @@ public struct SwiftDownEditor: UIViewRepresentable {
           self.parent.text = textView.text
         }
       }
+      
+      public func textViewDidChangeSelection(_ textView: UITextView) {
+        self.parent.selectedRange = textView.selectedRange
+      }
     }
   }
 
@@ -122,17 +133,25 @@ public struct SwiftDownEditor: UIViewRepresentable {
       }
     }
 
+    @Binding var selectedRange: NSRange {
+      didSet {
+        onSelectedRangeChange(selectedRange)
+      }
+    }
+    
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
     private(set) var insetsSize: CGFloat = 0
 
     public var onTextChange: (String) -> Void = { _ in }
+    private(set) var onSelectedRangeChange: (NSRange) -> Void = { _ in }
 
     public init(
       text: Binding<String>,
       onTextChange: @escaping (String) -> Void = { _ in }
     ) {
       _text = text
+      _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
     }
 
@@ -172,6 +191,14 @@ public struct SwiftDownEditor: UIViewRepresentable {
         }
 
         self.parent.text = textView.string
+      }
+      
+      public func textViewDidChangeSelection(_ notification: Notification) {
+        guard let textView = notification.object as? NSTextView else {
+          return
+        }
+
+        self.parent.selectedRange = textView.selectedRange()
       }
     }
   }

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -218,6 +218,11 @@ extension SwiftDownEditor {
     return editor
   }
 
+  public func onSelectedRangeChange(_ f:@escaping (NSRange) -> Void) -> Self {
+    var editor = self
+    editor.onSelectedRangeChange = f
+    return editor
+  }
   public func isEditable(_ isEditable: Bool) -> Self {
     var editor = self
     editor.isEditable = isEditable

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -17,11 +17,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     }
   }
 
-    @Binding var selectedRange: NSRange {
-      didSet {
-        onSelectedRangeChange(selectedRange)
-      }
-    }
+    @Binding var selectedRange: NSRange
 
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
@@ -32,7 +28,6 @@ public struct SwiftDownEditor: UIViewRepresentable {
     private(set) var textAlignment: TextAlignment = .leading
 
     public var onTextChange: (String) -> Void = { _ in }
-    private(set) var onSelectedRangeChange: (NSRange) -> Void = { _ in }
     let engine = MarkdownEngine()
 
     public init(
@@ -40,12 +35,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
       onTextChange: @escaping (String) -> Void = { _ in }
     ) {
       _text = text
-      var dummy = NSRange()
-      _selectedRange = .init(get: {
-        dummy
-      }, set: { rng in
-        dummy = rng
-      })
+      _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
     }
 
@@ -153,30 +143,20 @@ public struct SwiftDownEditor: UIViewRepresentable {
       }
     }
 
-    @Binding var selectedRange: NSRange {
-      didSet {
-        onSelectedRangeChange(selectedRange)
-      }
-    }
+    @Binding var selectedRange: NSRange
     
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
     private(set) var insetsSize: CGFloat = 0
 
     public var onTextChange: (String) -> Void = { _ in }
-    private(set) var onSelectedRangeChange: (NSRange) -> Void = { _ in }
 
     public init(
       text: Binding<String>,
       onTextChange: @escaping (String) -> Void = { _ in }
     ) {
       _text = text
-      var dummy = NSRange()
-      _selectedRange = .init(get: {
-        dummy
-      }, set: { rng in
-        dummy = rng
-      })
+      _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
     }
     
@@ -250,12 +230,6 @@ extension SwiftDownEditor {
   public func theme(_ theme: Theme) -> Self {
     var editor = self
     editor.theme = theme
-    return editor
-  }
-
-  public func onSelectedRangeChange(_ f:@escaping (NSRange) -> Void) -> Self {
-    var editor = self
-    editor.onSelectedRangeChange = f
     return editor
   }
   

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -17,8 +17,6 @@ public struct SwiftDownEditor: UIViewRepresentable {
     }
   }
 
-    @Binding var selectedRange: NSRange
-
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
     private(set) var insetsSize: CGFloat = 0
@@ -28,25 +26,17 @@ public struct SwiftDownEditor: UIViewRepresentable {
     private(set) var textAlignment: TextAlignment = .leading
 
     public var onTextChange: (String) -> Void = { _ in }
+    public var onSelectionChange: (NSRange) -> Void = { _ in }
     let engine = MarkdownEngine()
 
     public init(
       text: Binding<String>,
-      onTextChange: @escaping (String) -> Void = { _ in }
+      onTextChange: @escaping (String) -> Void = { _ in },
+      onSelectionChange: @escaping (NSRange) -> Void = { _ in }
     ) {
       _text = text
-      _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
-    }
-
-    public init(
-      text: Binding<String>,
-      selectedRange: Binding<NSRange>,
-      onTextChange: @escaping (String) -> Void = { _ in }
-    ) {
-      _text = text
-      _selectedRange = selectedRange
-      self.onTextChange = onTextChange
+      self.onSelectionChange = onSelectionChange
     }
 
     public func makeUIView(context: Context) -> SwiftDown {
@@ -100,10 +90,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
 
       public func textViewDidChangeSelection(_ textView: UITextView) {
         guard textView.markedTextRange == nil else { return }
-
-        DispatchQueue.main.async {
-          self.parent.selectedRange = textView.selectedRange
-        }
+        self.parent.onSelectionChange(textView.selectedRange)
       }
     }
   }
@@ -143,31 +130,21 @@ public struct SwiftDownEditor: UIViewRepresentable {
       }
     }
 
-    @Binding var selectedRange: NSRange
-    
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
     private(set) var insetsSize: CGFloat = 0
 
     public var onTextChange: (String) -> Void = { _ in }
+    public var onSelectionChange: (NSRange) -> Void = { _ in }
 
     public init(
       text: Binding<String>,
-      onTextChange: @escaping (String) -> Void = { _ in }
+      onTextChange: @escaping (String) -> Void = { _ in },
+      onSelectionChange: @escaping (NSRange) -> Void = { _ in }
     ) {
       _text = text
-      _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
-    }
-    
-    public init(
-      text: Binding<String>,
-      selectedRange: Binding<NSRange>,
-      onTextChange: @escaping (String) -> Void = { _ in }
-    ) {
-      _text = text
-      _selectedRange = selectedRange
-      self.onTextChange = onTextChange
+      self.onSelectionChange = onSelectionChange
     }
 
     public func makeNSView(context: Context) -> SwiftDown {
@@ -212,9 +189,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
         guard let textView = notification.object as? NSTextView else {
           return
         }
-        DispatchQueue.main.async {
-          self.parent.selectedRange = textView.selectedRange()
-        }
+        self.parent.onSelectionChange(textView.selectedRange())
       }
     }
   }

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -43,6 +43,16 @@ public struct SwiftDownEditor: UIViewRepresentable {
       self.onTextChange = onTextChange
     }
 
+    public init(
+      text: Binding<String>,
+      selectedRange: Binding<NSRange>,
+      onTextChange: @escaping (String) -> Void = { _ in }
+    ) {
+      _text = text
+      _selectedRange = selectedRange
+      self.onTextChange = onTextChange
+    }
+  
     public func makeUIView(context: Context) -> SwiftDown {
       let swiftDown = SwiftDown(frame: .zero, theme: theme)
       swiftDown.storage.markdowner = { self.engine.render($0, offset: $1) }
@@ -154,6 +164,16 @@ public struct SwiftDownEditor: UIViewRepresentable {
       _selectedRange = .constant(NSRange())
       self.onTextChange = onTextChange
     }
+    
+    public init(
+      text: Binding<String>,
+      selectedRange: Binding<NSRange>,
+      onTextChange: @escaping (String) -> Void = { _ in }
+    ) {
+      _text = text
+      _selectedRange = selectedRange
+      self.onTextChange = onTextChange
+    }
 
     public func makeNSView(context: Context) -> SwiftDown {
       let swiftDown = SwiftDown(theme: theme, isEditable: isEditable, insetsSize: insetsSize)
@@ -223,6 +243,7 @@ extension SwiftDownEditor {
     editor.onSelectedRangeChange = f
     return editor
   }
+  
   public func isEditable(_ isEditable: Bool) -> Self {
     var editor = self
     editor.isEditable = isEditable

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -16,6 +16,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
       onTextChange(text)
     }
   }
+
     @Binding var selectedRange: NSRange {
       didSet {
         onSelectedRangeChange(selectedRange)
@@ -39,7 +40,12 @@ public struct SwiftDownEditor: UIViewRepresentable {
       onTextChange: @escaping (String) -> Void = { _ in }
     ) {
       _text = text
-      _selectedRange = .constant(NSRange())
+      var dummy = NSRange()
+      _selectedRange = .init(get: {
+        dummy
+      }, set: { rng in
+        dummy = rng
+      })
       self.onTextChange = onTextChange
     }
 
@@ -165,7 +171,12 @@ public struct SwiftDownEditor: UIViewRepresentable {
       onTextChange: @escaping (String) -> Void = { _ in }
     ) {
       _text = text
-      _selectedRange = .constant(NSRange())
+      var dummy = NSRange()
+      _selectedRange = .init(get: {
+        dummy
+      }, set: { rng in
+        dummy = rng
+      })
       self.onTextChange = onTextChange
     }
     

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -207,13 +207,14 @@ public struct SwiftDownEditor: UIViewRepresentable {
 
         self.parent.text = textView.string
       }
-      
+
       public func textViewDidChangeSelection(_ notification: Notification) {
         guard let textView = notification.object as? NSTextView else {
           return
         }
-
-        self.parent.selectedRange = textView.selectedRange()
+        DispatchQueue.main.async {
+          self.parent.selectedRange = textView.selectedRange()
+        }
       }
     }
   }
@@ -232,7 +233,7 @@ extension SwiftDownEditor {
     editor.theme = theme
     return editor
   }
-  
+
   public func isEditable(_ isEditable: Bool) -> Self {
     var editor = self
     editor.isEditable = isEditable

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -52,7 +52,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
       _selectedRange = selectedRange
       self.onTextChange = onTextChange
     }
-  
+
     public func makeUIView(context: Context) -> SwiftDown {
       let swiftDown = SwiftDown(frame: .zero, theme: theme)
       swiftDown.storage.markdowner = { self.engine.render($0, offset: $1) }
@@ -101,9 +101,13 @@ public struct SwiftDownEditor: UIViewRepresentable {
           self.parent.text = textView.text
         }
       }
-      
+
       public func textViewDidChangeSelection(_ textView: UITextView) {
-        self.parent.selectedRange = textView.selectedRange
+        guard textView.markedTextRange == nil else { return }
+
+        DispatchQueue.main.async {
+          self.parent.selectedRange = textView.selectedRange
+        }
       }
     }
   }

--- a/SwiftDownDemo/Shared/ContentView.swift
+++ b/SwiftDownDemo/Shared/ContentView.swift
@@ -24,12 +24,10 @@ struct ContentView: View {
         self.focusedField = .field
       }
       TextEditor(text: $text)
-      HStack {
-        Button {
-          self.text = ""
-        } label: {
-          Text("Clear")
-        }
+      Button {
+        self.text = ""
+      } label: {
+        Text("Clear")
       }
     }
   }

--- a/SwiftDownDemo/Shared/ContentView.swift
+++ b/SwiftDownDemo/Shared/ContentView.swift
@@ -10,25 +10,26 @@ import SwiftDown
 
 struct ContentView: View {
   @State private var text: String = "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n**bold** __bold__\n*italic* _italic_\n`inline code`\n```\ncode block\n```\n\n> block quote\n\n- list\n\n1. list\n\n[link](link)\n\nbody"
+  @State private var selectedRange: NSRange = NSRange()
   @FocusState private var focusedField: FocusField?
 
   var body: some View {
     VStack {
-      SwiftDownEditor(text: $text, onTextChange: { text in
+      SwiftDownEditor(text: $text, selectedRange: $selectedRange, onTextChange: { text in
         print("onTextChange")
-      })
-      .onSelectedRangeChange({ rng in
-        print("onSelectedRangeChange", rng)
       })
       .focused($focusedField, equals: .field)
       .onAppear {
         self.focusedField = .field
       }
       TextEditor(text: $text)
-      Button {
-        self.text = ""
-      } label: {
-        Text("Clear")
+      HStack {
+        Text("selected \(selectedRange.description)")
+        Button {
+          self.text = ""
+        } label: {
+          Text("Clear")
+        }
       }
     }
   }

--- a/SwiftDownDemo/Shared/ContentView.swift
+++ b/SwiftDownDemo/Shared/ContentView.swift
@@ -17,6 +17,9 @@ struct ContentView: View {
       SwiftDownEditor(text: $text, onTextChange: { text in
         print("onTextChange")
       })
+      .onSelectedRangeChange({ rng in
+        print("onSelectedRangeChange", rng)
+      })
       .focused($focusedField, equals: .field)
       .onAppear {
         self.focusedField = .field

--- a/SwiftDownDemo/Shared/ContentView.swift
+++ b/SwiftDownDemo/Shared/ContentView.swift
@@ -10,13 +10,14 @@ import SwiftDown
 
 struct ContentView: View {
   @State private var text: String = "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n**bold** __bold__\n*italic* _italic_\n`inline code`\n```\ncode block\n```\n\n> block quote\n\n- list\n\n1. list\n\n[link](link)\n\nbody"
-  @State private var selectedRange: NSRange = NSRange()
   @FocusState private var focusedField: FocusField?
 
   var body: some View {
     VStack {
-      SwiftDownEditor(text: $text, selectedRange: $selectedRange, onTextChange: { text in
+      SwiftDownEditor(text: $text, onTextChange: { text in
         print("onTextChange")
+      }, onSelectionChange: { rng in
+        print("onSelectionChange", rng)
       })
       .focused($focusedField, equals: .field)
       .onAppear {
@@ -24,7 +25,6 @@ struct ContentView: View {
       }
       TextEditor(text: $text)
       HStack {
-        Text("selected \(selectedRange.description)")
         Button {
           self.text = ""
         } label: {


### PR DESCRIPTION
## Description

To what I understood, which can be wrong, the UITextView/NSTextView is hidden therefore it's impossible to know where the cursor is within the document. So I exposed both bindable for selection range value.

## Example

It's working for my iOS application and `SwiftDownDemo`.

Feel free to close or request changes. I'm happy to contribute.