### PR TITLE
perf: use combine

### DIFF
--- a/Sources/SwiftDown/SwiftDown.swift
+++ b/Sources/SwiftDown/SwiftDown.swift
@@ -47,6 +47,16 @@
     public override func willMove(toSuperview newSuperview: UIView?) {
       self.highlighter = SwiftDownHighligther(textView: self)
     }
+    var selectedRanges: [NSRange] {
+      get {
+        return [self.selectedRange]
+      }
+      set {
+        if !newValue.isEmpty {
+          self.selectedRange = newValue[0]
+        }
+      }
+    }
   }
 #else
   import AppKit

--- a/Sources/SwiftDown/SwiftDown.swift
+++ b/Sources/SwiftDown/SwiftDown.swift
@@ -5,7 +5,6 @@
 //  Created by Quentin Eude on 16/03/2021.
 //
 
-import Combine
 #if os(iOS)
   import UIKit
 
@@ -199,10 +198,6 @@ import Combine
     func applyStyles() {
       assert(highlighter != nil)
       highlighter.applyStyles()
-    }
-
-    func textChangeNotification() -> NotificationCenter.Publisher {
-      return NotificationCenter.default.publisher(for: NSText.didChangeNotification, object: textView)
     }
   }
 #endif

--- a/Sources/SwiftDown/SwiftDown.swift
+++ b/Sources/SwiftDown/SwiftDown.swift
@@ -5,6 +5,7 @@
 //  Created by Quentin Eude on 16/03/2021.
 //
 
+import Combine
 #if os(iOS)
   import UIKit
 
@@ -198,6 +199,10 @@
     func applyStyles() {
       assert(highlighter != nil)
       highlighter.applyStyles()
+    }
+
+    func textChangeNotification() -> NotificationCenter.Publisher {
+      return NotificationCenter.default.publisher(for: NSText.didChangeNotification, object: textView)
     }
   }
 #endif

--- a/Sources/SwiftDown/SwiftDown.swift
+++ b/Sources/SwiftDown/SwiftDown.swift
@@ -47,16 +47,6 @@
     public override func willMove(toSuperview newSuperview: UIView?) {
       self.highlighter = SwiftDownHighligther(textView: self)
     }
-    var selectedRanges: [NSRange] {
-      get {
-        return [self.selectedRange]
-      }
-      set {
-        if !newValue.isEmpty {
-          self.selectedRange = newValue[0]
-        }
-      }
-    }
   }
 #else
   import AppKit

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -64,20 +64,13 @@ public struct SwiftDownEditor: UIViewRepresentable {
   }
 
     public func makeCoordinator() -> Coordinator {
-      Coordinator(self)
+      Coordinator(self, debounceTime)
     }
   }
 
   // MARK: - SwiftDownEditor iOS Coordinator
   extension SwiftDownEditor {
     public class Coordinator: StyleCoordinator, UITextViewDelegate {
-      var parent: SwiftDownEditor
-
-      init(_ parent: SwiftDownEditor) {
-        self.parent = parent
-        super.init()
-      }
-
       public func textViewDidChange(_ textView: UITextView) {
         guard textView.markedTextRange == nil else { return }
 
@@ -151,7 +144,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     }
 
     public func makeCoordinator() -> Coordinator {
-      Coordinator(self)
+      Coordinator(self, debounceTime)
     }
   }
 
@@ -159,12 +152,6 @@ public struct SwiftDownEditor: UIViewRepresentable {
   extension SwiftDownEditor {
     // MARK: - Coordinator
     public class Coordinator: StyleCoordinator, NSTextViewDelegate {
-      var parent: SwiftDownEditor
-      init(_ parent: SwiftDownEditor) {
-        self.parent = parent
-        super.init()
-      }
-
       public func textDidChange(_ notification: Notification) {
         guard let textView = notification.object as? NSTextView else {
           return
@@ -177,10 +164,12 @@ public struct SwiftDownEditor: UIViewRepresentable {
 #endif
 
 public class StyleCoordinator: NSObject {
+  var parent: SwiftDownEditor
   private var subject = PassthroughSubject<(SwiftDown, String), Never>()
   private var subscription: AnyCancellable
-  override init() {
-    self.subscription = self.subject.debounce(for: .seconds(0.3), scheduler: RunLoop.main).sink { (nsView, text) in
+  init(_ parent: SwiftDownEditor, _ debounceTime: CGFloat) {
+    self.parent = parent
+    self.subscription = self.subject.debounce(for: .seconds(debounceTime), scheduler: RunLoop.main).sink { (nsView, text) in
       let selectedRanges = nsView.selectedRanges
       nsView.text = text
       nsView.highlighter?.applyStyles()

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -64,13 +64,20 @@ public struct SwiftDownEditor: UIViewRepresentable {
   }
 
     public func makeCoordinator() -> Coordinator {
-      Coordinator(self, debounceTime)
+      Coordinator(self)
     }
   }
 
   // MARK: - SwiftDownEditor iOS Coordinator
   extension SwiftDownEditor {
     public class Coordinator: StyleCoordinator, UITextViewDelegate {
+      var parent: SwiftDownEditor
+
+      init(_ parent: SwiftDownEditor) {
+        self.parent = parent
+        super.init()
+      }
+
       public func textViewDidChange(_ textView: UITextView) {
         guard textView.markedTextRange == nil else { return }
 
@@ -144,7 +151,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     }
 
     public func makeCoordinator() -> Coordinator {
-      Coordinator(self, debounceTime)
+      Coordinator(self)
     }
   }
 
@@ -152,6 +159,12 @@ public struct SwiftDownEditor: UIViewRepresentable {
   extension SwiftDownEditor {
     // MARK: - Coordinator
     public class Coordinator: StyleCoordinator, NSTextViewDelegate {
+      var parent: SwiftDownEditor
+      init(_ parent: SwiftDownEditor) {
+        self.parent = parent
+        super.init()
+      }
+
       public func textDidChange(_ notification: Notification) {
         guard let textView = notification.object as? NSTextView else {
           return
@@ -164,12 +177,10 @@ public struct SwiftDownEditor: UIViewRepresentable {
 #endif
 
 public class StyleCoordinator: NSObject {
-  var parent: SwiftDownEditor
   private var subject = PassthroughSubject<(SwiftDown, String), Never>()
   private var subscription: AnyCancellable
-  init(_ parent: SwiftDownEditor, _ debounceTime: CGFloat) {
-    self.parent = parent
-    self.subscription = self.subject.debounce(for: .seconds(debounceTime), scheduler: RunLoop.main).sink { (nsView, text) in
+  override init() {
+    self.subscription = self.subject.debounce(for: .seconds(0.3), scheduler: RunLoop.main).sink { (nsView, text) in
       let selectedRanges = nsView.selectedRanges
       nsView.text = text
       nsView.highlighter?.applyStyles()

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -7,6 +7,7 @@
 
 import Down
 import SwiftUI
+import Combine
 
 #if os(iOS)
   // MARK: - SwiftDownEditor iOS
@@ -24,6 +25,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     private(set) var autocorrectionType: UITextAutocorrectionType = .default
     private(set) var keyboardType: UIKeyboardType = .default
     private(set) var textAlignment: TextAlignment = .leading
+    private(set) var debounceTime: Double = 0.5
 
     public var onTextChange: (String) -> Void = { _ in }
     let engine = MarkdownEngine()
@@ -53,15 +55,20 @@ public struct SwiftDownEditor: UIViewRepresentable {
       swiftDown.tintColor = theme.tintColor
       swiftDown.textColor = theme.tintColor
       swiftDown.text = text
+
+      context.coordinator.cancellable = NotificationCenter.default
+        .publisher(for: SwiftDown.textDidChangeNotification, object: swiftDown)
+        .debounce(for: .seconds(debounceTime), scheduler: RunLoop.main)
+        .sink { _ in
+          let selectedRange = swiftDown.selectedRange
+          swiftDown.text = text
+          swiftDown.highlighter?.applyStyles()
+          swiftDown.selectedRange = selectedRange
+        }
       return swiftDown
     }
 
-    public func updateUIView(_ uiView: SwiftDown, context: Context) {
-      let selectedRange = uiView.selectedRange
-      uiView.text = text
-      uiView.highlighter?.applyStyles()
-      uiView.selectedRange = selectedRange
-    }
+    public func updateUIView(_ uiView: SwiftDown, context: Context) {}
 
     public func makeCoordinator() -> Coordinator {
       Coordinator(self)
@@ -71,6 +78,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
   // MARK: - SwiftDownEditor iOS Coordinator
   extension SwiftDownEditor {
     public class Coordinator: NSObject, UITextViewDelegate {
+      public var cancellable: Cancellable?
       var parent: SwiftDownEditor
 
       init(_ parent: SwiftDownEditor) {
@@ -125,6 +133,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     private(set) var isEditable: Bool = true
     private(set) var theme: Theme = Theme.BuiltIn.defaultDark.theme()
     private(set) var insetsSize: CGFloat = 0
+    private(set) var debounceTime: Double = 0.5
 
     public var onTextChange: (String) -> Void = { _ in }
 
@@ -141,15 +150,20 @@ public struct SwiftDownEditor: UIViewRepresentable {
       swiftDown.delegate = context.coordinator
       swiftDown.setupTextView()
       swiftDown.text = text
+
+      context.coordinator.cancellable = swiftDown.textChangeNotification()
+        .debounce(for: .seconds(debounceTime), scheduler: RunLoop.main)
+        .sink { _ in
+          let selectedRanges = swiftDown.selectedRanges
+          swiftDown.text = text
+          swiftDown.applyStyles()
+          swiftDown.selectedRanges = selectedRanges
+        }
+
       return swiftDown
     }
 
-    public func updateNSView(_ nsView: SwiftDown, context: Context) {
-      let selectedRanges = nsView.selectedRanges
-      nsView.text = text
-      nsView.applyStyles()
-      nsView.selectedRanges = selectedRanges
-    }
+    public func updateNSView(_ nsView: SwiftDown, context: Context) {}
 
     public func makeCoordinator() -> Coordinator {
       Coordinator(self)
@@ -160,6 +174,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
   extension SwiftDownEditor {
     // MARK: - Coordinator
     public class Coordinator: NSObject, NSTextViewDelegate {
+      public var cancellable: Cancellable?
       var parent: SwiftDownEditor
 
       init(_ parent: SwiftDownEditor) {
@@ -194,6 +209,12 @@ extension SwiftDownEditor {
   public func isEditable(_ isEditable: Bool) -> Self {
     var editor = self
     editor.isEditable = isEditable
+    return editor
+  }
+  
+  public func debounceTime(_ debounceTime: Double) -> Self {
+    var editor = self
+    editor.debounceTime = debounceTime
     return editor
   }
 }

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -13,7 +13,6 @@ import Combine
   // MARK: - SwiftDownEditor iOS
 public struct SwiftDownEditor: UIViewRepresentable {
   private var debounceTime = 0.3
-  private var styleUpdateCue = PassthroughSubject<Any, Never>()
   @Binding var text: String {
     didSet {
       onTextChange(text)

--- a/SwiftDownDemo/Shared/ContentView.swift
+++ b/SwiftDownDemo/Shared/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
       SwiftDownEditor(text: $text, onTextChange: { text in
         print("onTextChange")
       })
+      .debounceTime(0.3)
       .focused($focusedField, equals: .field)
       .onAppear {
         self.focusedField = .field

--- a/SwiftDownDemo/Shared/ContentView.swift
+++ b/SwiftDownDemo/Shared/ContentView.swift
@@ -17,7 +17,6 @@ struct ContentView: View {
       SwiftDownEditor(text: $text, onTextChange: { text in
         print("onTextChange")
       })
-      .debounceTime(0.3)
       .focused($focusedField, equals: .field)
       .onAppear {
         self.focusedField = .field


### PR DESCRIPTION
## Description

As I was using it I felt the editor was too slow.  Also there was a bug where if I type lot of characters in a second then the cursor would change it's location unexpectedly. So I debugged a bit and found it parses and renders on every `updateUIView` or `updateNSView`. I thought it caused too much overhead.

So I thought reactive pattern would fit very well in this case so I tried and the result was much smoother and faster. The bug was fixed as well. Please consider merging this PR. Thank you.

Feel free to close the PR or request changes. I'm happy to contribute.

## Example

Please try SwiftDownDemo on both MacOS and iPad OS.