### PR TITLE
🐛 honor isEditable setting in iOS version

### DIFF
--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -47,7 +47,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
       swiftDown.storage.applyMarkdown = { m in Theme.applyMarkdown(markdown: m, with: self.theme) }
       swiftDown.storage.applyBody = { Theme.applyBody(with: self.theme) }
       swiftDown.delegate = context.coordinator
-      swiftDown.isEditable = true
+      swiftDown.isEditable = isEditable
       swiftDown.isScrollEnabled = true
       swiftDown.keyboardType = keyboardType
       swiftDown.autocapitalizationType = autocapitalizationType


### PR DESCRIPTION
## Description

Small change to honor the `isEditable` setting on the iOS version by using the variable instead of the hardcoded `true` value in the `SwiftDownEditor.makeUIView` function

## Example

N/A
