### PR TITLE
feat: add markdown keyboard toolbar

### DIFF
--- a/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
+++ b/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
@@ -1,0 +1,266 @@
+//
+//  MarkdownKeyboardToolbar.swift
+//
+//
+//  Created by Ross Brandon on 18/01/24.
+//
+
+#if os(iOS)
+import UIKit
+
+/// Extends the SwiftDown UITextView to add a keyboard toolbar
+/// Toolbar buttons insert common Markdown syntax:
+/// - H1 heading text
+/// - H2 heading text
+/// - H3 heading text
+/// - Bold text
+/// - Italicized text
+/// - Unordered lists
+/// - Ordered lists
+/// - Block quotes
+/// - Links
+/// - Code Blocks
+extension SwiftDown {
+  /// Adds a keyboard toolbar for quick markdown syntax
+  /// Adds the selected markdown at the cursor's position
+  func addKeyboardToolbar() {
+    let toolbar = UIToolbar()
+    toolbar.barStyle = UIBarStyle.default
+    toolbar.isTranslucent = true
+    let h1Button = getKeyboardTextButton(title: "H1", action: #selector(self.h1Action))
+    let h2Button = getKeyboardTextButton(title: "H2", action: #selector(self.h2Action))
+    let h3Button = getKeyboardTextButton(title: "H3", action: #selector(self.h3Action))
+    let boldButton = getKeyboardImageButton(icon: "bold", action: #selector(self.boldAction))
+    let italicizeButton = getKeyboardImageButton(icon: "italic", action: #selector(self.italicizeAction))
+    let unorderedListButton = getKeyboardImageButton(
+      icon: "list.bullet",
+      action: #selector(self.unorderedListAction)
+    )
+    let orderedListButton = getKeyboardImageButton(
+      icon: "list.number",
+      action: #selector(self.orderedListAction)
+    )
+    let blockQuoteButton = getKeyboardImageButton(
+      icon: "quote.closing",
+      action: #selector(self.blockQuoteAction)
+    )
+    let linkButton = getKeyboardImageButton(icon: "link", action: #selector(self.linkAction))
+    let codeBlockButton = getKeyboardImageButton(icon: "curlybraces", action: #selector(self.codeBlockAction))
+    toolbar.setItems(
+      [
+        h1Button,
+        h2Button,
+        h3Button,
+        boldButton,
+        italicizeButton,
+        unorderedListButton,
+        orderedListButton,
+        blockQuoteButton,
+        linkButton,
+        codeBlockButton
+      ],
+      animated: false
+    )
+    toolbar.isUserInteractionEnabled = true
+    toolbar.sizeToFit()
+    self.inputAccessoryView = toolbar
+  }
+
+  private func getKeyboardTextButton(title: String, action: Selector) -> UIBarButtonItem {
+    return UIBarButtonItem(
+      title: title,
+      style: .plain,
+      target: self,
+      action: action
+    )
+  }
+
+  private func getKeyboardImageButton(icon: String, action: Selector) -> UIBarButtonItem {
+    return UIBarButtonItem(
+      image: UIImage(systemName: icon),
+      style: .plain,
+      target: self,
+      action: action
+    )
+  }
+
+  /// Inserts the H1 `#` tag
+  /// Adds 1 trailing whitespace at the current cursor position
+  /// Moves the cursor position after the inserted characters
+  @objc private func h1Action() {
+    let selectedStart = self.selectedStart
+    self.text.insert(contentsOf: "# ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.moveCursor(selectedStart + 2)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the H2 `##` tag
+  /// Adds 1 trailing whitespace at the current cursor position
+  /// Moves the cursor position after the inserted characters
+  @objc private func h2Action() {
+    let selectedStart = self.selectedStart
+    self.text.insert(contentsOf: "## ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.moveCursor(selectedStart + 3)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the H3 `###` tag
+  /// Adds 1 trailing whitespace at the current cursor position
+  /// Moves the cursor position after the inserted characters
+  @objc private func h3Action() {
+    let selectedStart = self.selectedStart
+    self.text.insert(contentsOf: "### ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.moveCursor(selectedStart + 4)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the bold`** **` tag
+  /// If text is selected, surrounds the selected text with the bold tags
+  /// Moves the cursor to the end of the selected text, if applicable
+  @objc private func boldAction() {
+    let selectedStart = self.selectedStart
+    let selectedEnd = self.selectedEnd
+    self.text.insert(contentsOf: "**", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.text.insert(contentsOf: "**", at: self.text.index(self.text.startIndex, offsetBy: selectedEnd + 2))
+    self.moveCursor(selectedEnd + 2)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the italic`* *` tag
+  /// If text is selected, surrounds the selected text with the italic tags
+  /// Moves the cursor to the end of the selected text, if applicable
+  @objc private func italicizeAction() {
+    let selectedStart = self.selectedStart
+    let selectedEnd = self.selectedEnd
+    self.text.insert(contentsOf: "*", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.text.insert(contentsOf: "*", at: self.text.index(self.text.startIndex, offsetBy: selectedEnd + 1))
+    self.moveCursor(selectedEnd + 1)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the unordered list`-` tag
+  /// Adds 1 leading line break
+  /// Adds 1 trailing whitespace at the current cursor position
+  @objc private func unorderedListAction() {
+    let selectedStart = self.selectedStart
+    self.text.insert(contentsOf: "\n- ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.moveCursor(selectedStart + 3)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the ordered list`1.` tag
+  /// Adds 1 leading line break
+  /// Adds 1 trailing whitespace at the current cursor position1
+  @objc private func orderedListAction() {
+    let selectedStart = self.selectedStart
+    self.text.insert(contentsOf: "\n1. ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.moveCursor(selectedStart + 3)
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the block quote `>` tag
+  /// Adds 1 trailing whitespace at the current cursor position
+  @objc private func blockQuoteAction() {
+    let selectedStart = self.selectedStart
+    self.text.insert(contentsOf: "> ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the link`[]()` tag
+  /// If text is selected, it is checked if it contains a link
+  ///   If a link is detected, the selected text is placed inside the parenthesis
+  ///   If a link is not detected, the selected text is placed inside the braces
+  /// Moves the cursor into the text bracket or parenthesis as applicable
+  @objc private func linkAction() {
+    let selectedStart = self.selectedStart
+    let selectedEnd = self.selectedEnd
+    if self.containsLink() {
+      self.text.insert(
+        contentsOf: "[](",
+        at: self.text.index(self.text.startIndex, offsetBy: selectedStart)
+    )
+      self.text.insert(
+        contentsOf: ")",
+        at: self.text.index(self.text.startIndex, offsetBy: selectedEnd + 3)
+    )
+      self.moveCursor(selectedStart + 1)
+    } else {
+      self.text.insert(
+        contentsOf: "[",
+        at: self.text.index(self.text.startIndex, offsetBy: selectedStart)
+      )
+      self.text.insert(
+        contentsOf: "]()",
+        at: self.text.index(self.text.startIndex, offsetBy: selectedEnd + 1)
+      )
+      self.moveCursor(selectedEnd + 3)
+    }
+    self.highlighter?.applyStyles()
+  }
+
+  /// Inserts the code block tag with line breaks
+  /// If text is selected, moves the selected text inside the code block
+  /// Adds line breaks to create the block
+  /// Moves the cursor into the code block at the end of the selected text, if applicable
+  @objc private func codeBlockAction() {
+    let selectedStart = self.selectedStart
+    let selectedEnd = self.selectedEnd
+    self.text.insert(
+      contentsOf: "```\n",
+      at: self.text.index(self.text.startIndex,
+      offsetBy: selectedStart)
+    )
+    self.text.insert(
+      contentsOf: "\n```",
+      at: self.text.index(self.text.startIndex, offsetBy: selectedEnd + 4)
+    )
+    self.moveCursor(selectedEnd + 4)
+    self.highlighter?.applyStyles()
+  }
+}
+
+/// Extends UITextView to provide cursor helper methods
+extension UITextView {
+  /// Get selected text range start position
+  var selectedStart: Int {
+    guard let selectedRange = self.selectedTextRange else {
+      return 0
+    }
+    return self.offset(from: self.beginningOfDocument, to: selectedRange.start)
+  }
+
+  /// Get selected text range end position
+  var selectedEnd: Int {
+    guard let selectedRange = self.selectedTextRange else {
+      return 0
+    }
+    return self.offset(from: self.beginningOfDocument, to: selectedRange.end)
+  }
+
+  /// Move cursor by the given offset
+  func moveCursor(_ offset: Int = 1) {
+    guard let newPosition = self.position(from: self.beginningOfDocument, offset: offset) else {
+      return
+    }
+    self.selectedTextRange = self.textRange(from: newPosition, to: newPosition)
+  }
+
+  /// Validate if the selected text range contains a link
+  func containsLink() -> Bool {
+    guard let selectedTextRange = self.selectedTextRange,
+      let selectedText = self.text(in: selectedTextRange) else {
+      return false
+    }
+    do {
+      let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+      let matches = detector.matches(
+        in: selectedText, options: [],
+        range: NSRange(location: 0, length: selectedText.utf16.count)
+      )
+      return !matches.isEmpty
+    } catch {
+      return false
+    }
+  }
+}
+#endif

--- a/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
+++ b/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
@@ -8,18 +8,6 @@
 #if os(iOS)
 import UIKit
 
-/// Extends the SwiftDown UITextView to add a keyboard toolbar
-/// Toolbar buttons insert common Markdown syntax:
-/// - H1 heading text
-/// - H2 heading text
-/// - H3 heading text
-/// - Bold text
-/// - Italicized text
-/// - Unordered lists
-/// - Ordered lists
-/// - Block quotes
-/// - Links
-/// - Code Blocks
 extension SwiftDown {
   /// Adds a keyboard toolbar for quick markdown syntax
   /// Adds the selected markdown at the cursor's position
@@ -27,25 +15,16 @@ extension SwiftDown {
     let toolbar = UIToolbar()
     toolbar.barStyle = UIBarStyle.default
     toolbar.isTranslucent = true
-    let h1Button = getKeyboardTextButton(title: "H1", action: #selector(self.h1Action))
-    let h2Button = getKeyboardTextButton(title: "H2", action: #selector(self.h2Action))
-    let h3Button = getKeyboardTextButton(title: "H3", action: #selector(self.h3Action))
-    let boldButton = getKeyboardImageButton(icon: "bold", action: #selector(self.boldAction))
-    let italicizeButton = getKeyboardImageButton(icon: "italic", action: #selector(self.italicizeAction))
-    let unorderedListButton = getKeyboardImageButton(
-      icon: "list.bullet",
-      action: #selector(self.unorderedListAction)
-    )
-    let orderedListButton = getKeyboardImageButton(
-      icon: "list.number",
-      action: #selector(self.orderedListAction)
-    )
-    let blockQuoteButton = getKeyboardImageButton(
-      icon: "quote.closing",
-      action: #selector(self.blockQuoteAction)
-    )
-    let linkButton = getKeyboardImageButton(icon: "link", action: #selector(self.linkAction))
-    let codeBlockButton = getKeyboardImageButton(icon: "curlybraces", action: #selector(self.codeBlockAction))
+    let h1Button = keyboardButton(title: "H1", action: #selector(self.h1Action))
+    let h2Button = keyboardButton(title: "H2", action: #selector(self.h2Action))
+    let h3Button = keyboardButton(title: "H3", action: #selector(self.h3Action))
+    let boldButton = keyboardButton(icon: "bold", action: #selector(self.boldAction))
+    let italicizeButton = keyboardButton(icon: "italic", action: #selector(self.italicizeAction))
+    let unorderedListButton = keyboardButton(icon: "list.bullet",action: #selector(self.unorderedListAction))
+    let orderedListButton = keyboardButton(icon: "list.number",action: #selector(self.orderedListAction))
+    let blockQuoteButton = keyboardButton(icon: "quote.closing",action: #selector(self.blockQuoteAction))
+    let linkButton = keyboardButton(icon: "link", action: #selector(self.linkAction))
+    let codeBlockButton = keyboardButton(icon: "curlybraces", action: #selector(self.codeBlockAction))
     toolbar.setItems(
       [
         h1Button,
@@ -66,8 +45,8 @@ extension SwiftDown {
     self.inputAccessoryView = toolbar
   }
 
-  private func getKeyboardTextButton(title: String, action: Selector) -> UIBarButtonItem {
-    return UIBarButtonItem(
+  private func keyboardButton(title: String, action: Selector) -> UIBarButtonItem {
+    UIBarButtonItem(
       title: title,
       style: .plain,
       target: self,
@@ -75,8 +54,8 @@ extension SwiftDown {
     )
   }
 
-  private func getKeyboardImageButton(icon: String, action: Selector) -> UIBarButtonItem {
-    return UIBarButtonItem(
+  private func keyboardButton(icon: String, action: Selector) -> UIBarButtonItem {
+    UIBarButtonItem(
       image: UIImage(systemName: icon),
       style: .plain,
       target: self,
@@ -168,13 +147,13 @@ extension SwiftDown {
 
   /// Inserts the link`[]()` tag
   /// If text is selected, it is checked if it contains a link
-  ///   If a link is detected, the selected text is placed inside the parenthesis
-  ///   If a link is not detected, the selected text is placed inside the braces
+  ///   If a link is detected, the selected text is placed inside the braces
+  ///   If a link is not detected, the selected text is placed inside the parenthesis
   /// Moves the cursor into the text bracket or parenthesis as applicable
   @objc private func linkAction() {
     let selectedStart = self.selectedStart
     let selectedEnd = self.selectedEnd
-    if self.containsLink() {
+    if self.containsLink {
       self.text.insert(
         contentsOf: "[](",
         at: self.text.index(self.text.startIndex, offsetBy: selectedStart)

--- a/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
+++ b/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
@@ -63,8 +63,6 @@ extension SwiftDown {
     )
   }
 
-  /// Inserts the H1 `#` tag
-  /// Adds 1 trailing whitespace at the current cursor position
   /// Moves the cursor position after the inserted characters
   @objc private func h1Action() {
     let selectedStart = self.selectedStart
@@ -73,8 +71,6 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the H2 `##` tag
-  /// Adds 1 trailing whitespace at the current cursor position
   /// Moves the cursor position after the inserted characters
   @objc private func h2Action() {
     let selectedStart = self.selectedStart
@@ -83,8 +79,6 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the H3 `###` tag
-  /// Adds 1 trailing whitespace at the current cursor position
   /// Moves the cursor position after the inserted characters
   @objc private func h3Action() {
     let selectedStart = self.selectedStart
@@ -93,7 +87,6 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the bold`** **` tag
   /// If text is selected, surrounds the selected text with the bold tags
   /// Moves the cursor to the end of the selected text, if applicable
   @objc private func boldAction() {
@@ -105,7 +98,6 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the italic`* *` tag
   /// If text is selected, surrounds the selected text with the italic tags
   /// Moves the cursor to the end of the selected text, if applicable
   @objc private func italicizeAction() {
@@ -117,9 +109,7 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the unordered list`-` tag
   /// Adds 1 leading line break
-  /// Adds 1 trailing whitespace at the current cursor position
   @objc private func unorderedListAction() {
     let selectedStart = self.selectedStart
     self.text.insert(contentsOf: "\n- ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
@@ -127,9 +117,7 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the ordered list`1.` tag
   /// Adds 1 leading line break
-  /// Adds 1 trailing whitespace at the current cursor position1
   @objc private func orderedListAction() {
     let selectedStart = self.selectedStart
     self.text.insert(contentsOf: "\n1. ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
@@ -137,15 +125,12 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the block quote `>` tag
-  /// Adds 1 trailing whitespace at the current cursor position
   @objc private func blockQuoteAction() {
     let selectedStart = self.selectedStart
     self.text.insert(contentsOf: "> ", at: self.text.index(self.text.startIndex, offsetBy: selectedStart))
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the link`[]()` tag
   /// If text is selected, it is checked if it contains a link
   ///   If a link is detected, the selected text is placed inside the braces
   ///   If a link is not detected, the selected text is placed inside the parenthesis
@@ -177,9 +162,7 @@ extension SwiftDown {
     self.highlighter?.applyStyles()
   }
 
-  /// Inserts the code block tag with line breaks
   /// If text is selected, moves the selected text inside the code block
-  /// Adds line breaks to create the block
   /// Moves the cursor into the code block at the end of the selected text, if applicable
   @objc private func codeBlockAction() {
     let selectedStart = self.selectedStart

--- a/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
+++ b/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
@@ -246,7 +246,7 @@ extension UITextView {
   }
 
   /// Validate if the selected text range contains a link
-  func containsLink() -> Bool {
+  var containsLink: Bool {
     guard let selectedTextRange = self.selectedTextRange,
       let selectedText = self.text(in: selectedTextRange) else {
       return false

--- a/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
+++ b/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
@@ -13,9 +13,6 @@ extension SwiftDown {
   /// Adds the selected markdown at the cursor's position
   func addKeyboardToolbar() {
     let toolbar = UIToolbar()
-    toolbar.barStyle = UIBarStyle.default
-    toolbar.isTranslucent = true
-    toolbar.barTintColor = UIColor.systemBackground
     let h1Button = keyboardButton(title: "H1", action: #selector(self.h1Action))
     let h2Button = keyboardButton(title: "H2", action: #selector(self.h2Action))
     let h3Button = keyboardButton(title: "H3", action: #selector(self.h3Action))
@@ -43,14 +40,20 @@ extension SwiftDown {
     )
     toolbar.isUserInteractionEnabled = true
     toolbar.sizeToFit()
-    let buttonCount = CGFloat(toolbar.items?.count ?? 0)
-    toolbar.frame = CGRect(x: 0, y: 0, width: 40 * buttonCount, height: toolbar.frame.size.height)
+    toolbar.barStyle = UIBarStyle.default
+    toolbar.isTranslucent = true
+    toolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
+    toolbar.backgroundColor = UIColor.secondarySystemBackground
+    let toolbarWidth = max(40 * CGFloat(toolbar.items?.count ?? 0), UIScreen.main.bounds.width)
+    toolbar.frame = CGRect(x: 0, y: 0, width: toolbarWidth, height: toolbar.frame.size.height)
     let scrollView = UIScrollView(frame:
       CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: toolbar.frame.size.height)
     )
-    scrollView.bounds = toolbar.bounds;
-    scrollView.contentSize = toolbar.frame.size;
-    scrollView.backgroundColor = UIColor.systemBackground
+    scrollView.showsHorizontalScrollIndicator = false
+    scrollView.showsVerticalScrollIndicator = false
+    scrollView.bounds = toolbar.bounds
+    scrollView.contentSize = toolbar.frame.size
+    scrollView.backgroundColor = UIColor.secondarySystemBackground
     scrollView.addSubview(toolbar)
     self.inputAccessoryView = scrollView
   }

--- a/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
+++ b/Sources/SwiftDown/MarkdownKeyboardToolbar.swift
@@ -15,6 +15,7 @@ extension SwiftDown {
     let toolbar = UIToolbar()
     toolbar.barStyle = UIBarStyle.default
     toolbar.isTranslucent = true
+    toolbar.barTintColor = UIColor.systemBackground
     let h1Button = keyboardButton(title: "H1", action: #selector(self.h1Action))
     let h2Button = keyboardButton(title: "H2", action: #selector(self.h2Action))
     let h3Button = keyboardButton(title: "H3", action: #selector(self.h3Action))
@@ -42,7 +43,16 @@ extension SwiftDown {
     )
     toolbar.isUserInteractionEnabled = true
     toolbar.sizeToFit()
-    self.inputAccessoryView = toolbar
+    let buttonCount = CGFloat(toolbar.items?.count ?? 0)
+    toolbar.frame = CGRect(x: 0, y: 0, width: 40 * buttonCount, height: toolbar.frame.size.height)
+    let scrollView = UIScrollView(frame:
+      CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: toolbar.frame.size.height)
+    )
+    scrollView.bounds = toolbar.bounds;
+    scrollView.contentSize = toolbar.frame.size;
+    scrollView.backgroundColor = UIColor.systemBackground
+    scrollView.addSubview(toolbar)
+    self.inputAccessoryView = scrollView
   }
 
   private func keyboardButton(title: String, action: Selector) -> UIBarButtonItem {

--- a/Sources/SwiftDown/SwiftDown.swift
+++ b/Sources/SwiftDown/SwiftDown.swift
@@ -12,6 +12,7 @@
   public class SwiftDown: UITextView, UITextViewDelegate {
     var storage: Storage = Storage()
     var highlighter: SwiftDownHighligther?
+    var hasKeyboardToolbar: Bool = true
 
     convenience init(frame: CGRect, theme: Theme) {
       self.init(frame: frame, textContainer: nil)
@@ -19,6 +20,9 @@
       self.backgroundColor = theme.backgroundColor
       self.tintColor = theme.tintColor
       self.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      if hasKeyboardToolbar {
+        self.addKeyboardToolbar()
+      }
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {

--- a/Sources/SwiftDown/SwiftDownEditor.swift
+++ b/Sources/SwiftDown/SwiftDownEditor.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SwiftDownEditor.swift
 //
 //
 //  Created by Quentin Eude on 16/03/2021.
@@ -25,6 +25,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
     private(set) var autocapitalizationType: UITextAutocapitalizationType = .sentences
     private(set) var autocorrectionType: UITextAutocorrectionType = .default
     private(set) var keyboardType: UIKeyboardType = .default
+    private(set) var hasKeyboardToolbar: Bool = true
     private(set) var textAlignment: TextAlignment = .leading
 
     public var onTextChange: (String) -> Void = { _ in }
@@ -50,6 +51,7 @@ public struct SwiftDownEditor: UIViewRepresentable {
       swiftDown.isEditable = true
       swiftDown.isScrollEnabled = true
       swiftDown.keyboardType = keyboardType
+      swiftDown.hasKeyboardToolbar = hasKeyboardToolbar
       swiftDown.autocapitalizationType = autocapitalizationType
       swiftDown.autocorrectionType = autocorrectionType
       swiftDown.textContainerInset = UIEdgeInsets(
@@ -130,6 +132,12 @@ public struct SwiftDownEditor: UIViewRepresentable {
       var new = self
       new.textAlignment = type
       return new
+    }
+
+    public func hasKeyboardToolbar(_ hasKeyboardToolbar: Bool) -> Self {
+      var editor = self
+      editor.hasKeyboardToolbar = hasKeyboardToolbar
+      return editor
     }
   }
 #else


### PR DESCRIPTION
## Description

Adds a keyboard toolbar to support easy insertion of markdown syntax.

### Supported buttons:
- Headings: H1, H2, and H3
- Bold text
- Italicized text
- Unordered lists
- Ordered lists
- Blockquotes
- Links
- Code blocks

### Changes:
- Create `MarkdownKeyboardToolbar` - `SwiftDownEditor` extension to attach a keyboard toolbar to the `UITextView`
- Add `hasKeyboardToolbar` modifier to `SwiftDownEditor`. The keyboard is enabled by default but can be disabled with the `.hasKeyboardToolbar(false)` modifier.
- Initialize keyboard toolbar within `SwiftDown` if `hasKeyboardToolbar` is enabled. 

## Example

### Screenshot:

<img width="430" alt="keyboard_toolbar_screenshot" src="https://github.com/qeude/SwiftDown/assets/31011626/38286e70-b691-4c84-b640-3de78b756f56">

### Screencast:

![keyboard_demo](https://github.com/qeude/SwiftDown/assets/31011626/809588a3-5fb3-4aed-b7ad-a46314849dad)
